### PR TITLE
Angular material

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -102,11 +102,11 @@ angular.module('myApp.Controllers',[])
       enableSorting:true,
       columnDefs:[
         {name: 'id', visible:false},
-        {name: 'Name', enableSorting:false, cellTemplate:'<a href="https://strava.com/routes/{{row.entity.id}}" target="_blank">{{COL_FIELD}}</a>'},
-        {name: 'Length', enableSorting:true},
-        {name: 'Elevation', enableSorting:true},
-        {name: 'Type', enableSorting:false, cellTemplate:'<div>{{COL_FIELD == 1 ? "Cycling" : "Running"}}</div>'},
-        {name: 'Subtype', enableSorting:false, cellTemplate:'<div>{{COL_FIELD == 1 ? "Road" : (COL_FIELD == 2 ? "Mountain" : (COL_FIELD == 3 ? "Cyclocross" : "Trail Run"))}}</div>'}
+        {name: 'Name', enableSorting:false, cellTemplate:'<a href="https://strava.com/routes/{{row.entity.id}}" target="_blank">{{COL_FIELD}}</a>', width:"*"},
+        {name: 'Length', enableSorting:true, width:80},
+        {name: 'Elevation', enableSorting:true, width:90},
+        {name: 'Type', enableSorting:false, cellTemplate:'<div>{{COL_FIELD == 1 ? "Cycling" : "Running"}}</div>', width:80},
+        {name: 'Subtype', enableSorting:false, cellTemplate:'<div>{{COL_FIELD == 1 ? "Road" : (COL_FIELD == 2 ? "Mountain" : (COL_FIELD == 3 ? "Cyclocross" : "Trail Run"))}}</div>', width:90}
         ],
         data:[]
     };

--- a/static/app.js
+++ b/static/app.js
@@ -102,11 +102,11 @@ angular.module('myApp.Controllers',[])
       enableSorting:true,
       columnDefs:[
         {name: 'id', visible:false},
-        {name: 'Name', enableSorting:false, cellTemplate:'<a href="https://strava.com/routes/{{row.entity.id}}" target="_blank">{{COL_FIELD}}</a>', width:"*"},
+        {name: 'Name', enableSorting:false, cellTemplate:'<a href="https://strava.com/routes/{{row.entity.id}}" target="_blank">{{COL_FIELD}}</a>', width:270},
         {name: 'Length', enableSorting:true, width:80},
         {name: 'Elevation', enableSorting:true, width:90},
         {name: 'Type', enableSorting:false, cellTemplate:'<div>{{COL_FIELD == 1 ? "Cycling" : "Running"}}</div>', width:80},
-        {name: 'Subtype', enableSorting:false, cellTemplate:'<div>{{COL_FIELD == 1 ? "Road" : (COL_FIELD == 2 ? "Mountain" : (COL_FIELD == 3 ? "Cyclocross" : "Trail Run"))}}</div>', width:90}
+        {name: 'Subtype', enableSorting:false, cellTemplate:'<div>{{COL_FIELD == 1 ? "Road" : (COL_FIELD == 2 ? "Mountain" : (COL_FIELD == 3 ? "Cyclocross" : "Trail Run"))}}</div>', width:"*"}
         ],
         data:[]
     };

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -1,9 +1,12 @@
 /* ui-grid */
 .myGrid {
-    width: 635px;
+    width: 640px;
     height: 350px;
   }
-
+.ui-grid-header-cell .ui-grid-cell-contents {
+    display: block;
+    width: calc(100% - 12px);
+}
 /* mdResource for tabs */
 .myApp md-content {
   background-color: transparent !important; }
@@ -56,4 +59,4 @@
 }
 
 /* Resized textbox for location query inputs */
-.resizedTextbox {width: 300px; height: 20px}
+.resizedTextbox {width: 400px; height: 20px}

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -1,7 +1,7 @@
 /* ui-grid */
 .myGrid {
-    width: 500px;
-    height: 250px;
+    width: 635px;
+    height: 350px;
   }
 
 /* mdResource for tabs */

--- a/static/partials/form.html
+++ b/static/partials/form.html
@@ -49,13 +49,13 @@
           <span class="custom_tooltiptext">Your search will be more accurate if you use commas to separate fields.</span>
 
         </div>:<br>
-        <md-input-container>
+        <md-input-container class='resizedTextbox'>
         <label>Starting location</label>
-          <input type="text" ng-model="appForm.data.start_loc" class='resizedTextbox'>
-        </md-input-container>
-        <md-input-container>
+          <input type="text" ng-model="appForm.data.start_loc">
+        </md-input-container><br>
+        <md-input-container class='resizedTextbox'>
         <label>Ending location</label>
-          <input type="text" ng-model="appForm.data.end_loc" class='resizedTextbox'>
+          <input type="text" ng-model="appForm.data.end_loc">
         </md-input-container><br><br>
       </div>
   <input type='button' value='Reset' ng-click='reset()' />

--- a/static/partials/form.html
+++ b/static/partials/form.html
@@ -1,26 +1,47 @@
 <form ng-submit="appForm.submit()">
-  Distance (in meters) the route covers:<br>
-    <input type="number" placeholder="minimum" ng-model="appForm.data.dist_min">
-	  <input type="number" placeholder="maximum" ng-model="appForm.data.dist_max"><br><br>
-	Total elevation change (in meters) along the route:<br>
-    <input type="number" placeholder="minimum" ng-model="appForm.data.elev_min">
-	  <input type="number" placeholder="maximum" ng-model="appForm.data.elev_max"><br><br>
+<md-content layout-gt-sm="row" layout-padding>
+<div>
+  <span class="md-headline">Distance the route covers:</span><br>
+    <md-input-container>
+      <label>minimum</label>
+      <input type="number" ng-model="appForm.data.dist_min">
+    </md-input-container>
+    <md-input-container>
+      <label>maximum</label>
+  	  <input type="number" ng-model="appForm.data.dist_max">
+    </md-input-container>
+    <br><br>
+  <span class="md-headline">Total elevation change along the route:</span><br>
+    <md-input-container>
+      <label>minimum</label>
+      <input type="number" ng-model="appForm.data.elev_min">
+    </md-input-container>
+    <md-input-container>
+      <label>maximum</label>
+  	  <input type="number" ng-model="appForm.data.elev_max">
+    </md-input-container>
+    <br><br>
 
-	Route type:<br>  
-    <select ng-model='appForm.data.route_type'
-      ng-options='value.id as value.value for value in appForm.selection.base_type'>
-      <option value=''></option>
-    </select><br>
-  Route subtype:<br>
-    <select ng-model='appForm.data.route_subtype'
-      ng-options='value.id as value.value for value in appForm.selection.base_subtype'>
-      <option value=''></option>
-    </select><br>
+<span class="md-headline">Route types and subtypes:</span><br>
+  <md-input-container>
+  <label>type</label>
+    <md-select ng-model='appForm.data.route_type' ng-model-options="{trackBy: '$value'}">
+      <md-option ng-value="type.id" ng-repeat="type in appForm.selection.base_type">{{ type.value }}</md-option>
+      <md-option value=''>Any</md-option>
+    </md-select>
+  </md-input-container>
+  <md-input-container>
+  <label>subtype</label>
+    <md-select ng-model='appForm.data.route_subtype' ng-model-options="{trackBy: '$value'}">
+      <md-option ng-value="type.id" ng-repeat="type in appForm.selection.base_subtype">{{ type.value }}</md-option>
+      <md-option value=''>Any</md-option>
+    </md-select>
+  </md-input-container><br>
 
 
 	<!-- advanced options -->
-	  <input type='checkbox' ng-model="appForm.data.loop">Is complete loop<br>
-      <input type="checkbox" ng-model="checked" aria-label="Toggle ngHide" ng-change="clear_addresses()">search near a location<br />
+	  <md-checkbox ng-model="appForm.data.loop" aria-label='loop'>Is complete loop</md-checkbox><br>
+    <md-checkbox ng-model="checked" aria-label="Toggle ngHide" ng-change="clear_addresses()">search near a location</md-checkbox><br />
       <div class="check-element animate-show-hide" ng-show="checked">
 
         Search for routes starting near a
@@ -28,15 +49,20 @@
           <span class="custom_tooltiptext">Your search will be more accurate if you use commas to separate fields.</span>
 
         </div>:<br>
-
-        Starting location:<br>
-        <input type="text" placeholder="address, city, *state, *country, postcode" ng-model="appForm.data.start_loc" class='resizedTextbox'><br>
-        Ending location:<br>
-        <input type="text" placeholder="address, city, *state, *country, postcode" ng-model="appForm.data.end_loc" class='resizedTextbox'><br><br>
+        <md-input-container>
+        <label>Starting location</label>
+          <input type="text" ng-model="appForm.data.start_loc" class='resizedTextbox'>
+        </md-input-container>
+        <md-input-container>
+        <label>Ending location</label>
+          <input type="text" ng-model="appForm.data.end_loc" class='resizedTextbox'>
+        </md-input-container><br><br>
       </div>
   <input type='button' value='Reset' ng-click='reset()' />
   <input type='submit'/><br>
 
+</div>
+</md-content>
 </form>
 <toaster-container toaster-options="{'position-class': 'toast-center', 'close-button':true}"></toaster-container>
 

--- a/static/partials/list2.html
+++ b/static/partials/list2.html
@@ -1,5 +1,5 @@
 <!doctype html>
 <h2>Strava User-Created Routes</h2>
 <div>
-	<div ui-grid="gridOptions" class="grid"></div>
+	<div ui-grid="gridOptions" class="myGrid"></div>
 </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -8,7 +8,6 @@
 	<link href="https://cdnjs.cloudflare.com/ajax/libs/skeleton/2.0.4/skeleton.css" rel="stylesheet">
 	<link rel="styleSheet" href="https://cdnjs.cloudflare.com/ajax/libs/angular-ui-grid/4.0.2/ui-grid.min.css">
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/angular-material/1.1.3/angular-material.min.css">
-	<link rel="styleSheet" href="static/css/main.css">
 	<link rel="styleSheet" href="static/css/bootstrap.min.css">
 	<!-- <link href="static/css/my.css" rel="stylesheet"> -->
 	<!-- JS -->
@@ -22,6 +21,7 @@
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/angular-material/1.1.3/angular-material.min.js"></script>
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.5.5/angular-aria.min.js"></script>
 	<script src="static/app.js"></script>
+	<link rel="styleSheet" href="static/css/main.css">
 </head>
 
 <div id="main">

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html ng-app='myApp'>
 <meta charset="utf-8">
+<meta name=viewport content='width=700'>
 <head>
 	<!-- CSS-->
 	<link href="https://cdnjs.cloudflare.com/ajax/libs/angularjs-toaster/1.1.0/toaster.min.css" rel="stylesheet">
@@ -37,24 +38,24 @@
   			<md-tab label='About'>
   				<md-content class='md-padding'>
   					<h1 class='md-display-2'>About Us</h1>
-  						<p>
+  						<p><span style='word-wrap:break-word'>
                 In Fall of 2016 we became bothered that Strava doesn't provide a tool to search for routes. After looking around online, we found that others were annoyed by this as well. We're the kind of people that make things, fix things that are broken, and solve problems. Voilà!
-              </p>
+              </span></p>
               <p>
                 Find the code on <a href="https://github.com/lgoerl/stravapp">Github</a>. Tweet at us, @HANDLE.
               </p>
               <p>
                 <b>Bryan Bischof</b> <a href="mailto:bryan.bischof@gmail.com">Email.</a>
               </p>
-              <p>
+              <p><span style='word-wrap:break-word'>
                 Bryan is a software/data engineer at Blue Bottle Coffee and mathematics Ph.D., and the founder of <a href="mailto:www.quasicoherentlabs.com">Quasicoherent Labs</a>. He is deeply interested in words, culture, and any problem worth solving.
-              </p>
+              </span></p>
               <p>
                 <b>Lee Goerl</b> <a href="https://www.linkedin.com/in/lgoerl/">LinkedIn</a> <a href="mailto:lgoerl@gmail.com">Email.</a>
               </p>
-              <p>
+              <p><span style='word-wrap:break-word'>
                 <em>Lee is on the job market!</em> He is a founding member of <a href="mailto:www.quasicoherentlabs.com">Quasicoherent labs</a>, and a mathematics Ph.D. with training in statistics. He is especially interested in machine learning, and its application to natural language processing.
-              </p>
+              </span></p>
               <p>
                 <b>Jeff Larson</b> <a href="mailto:jeff.redsox@gmail.com">Email.</a>
               </p>
@@ -81,9 +82,9 @@
 		              <p>
 		                <b>How do you define loop?</b>
 		              </p>
-		              <p>
+		              <p><span style='word-wrap:break-word'>
 		                A continuous embedding of `S^1` into—oh sorry, I mean: the start and ending locations are both within a bounding box of relatively small size—which we determined to work similar to our expectations.
-		              </p>
+		              </span></p>
 		              <p>
 		                <b>Can't you do cool stuff with the segments data?</b>
 		              </p>


### PR DESCRIPTION
Moved all inputs to Angular Material's `md-input-container` instead of standard html inputs. Widened location input fields and stacked them.
Maked pages more mobile-friendly by:
- adjusting width of *About Us* and *FAQ* tabs
- adjusting width of `ui-grid` and its columns.